### PR TITLE
Nested Model support

### DIFF
--- a/lib/dgraph_ex.ex
+++ b/lib/dgraph_ex.ex
@@ -23,7 +23,6 @@ defmodule DgraphEx do
   use Query.As
   use Query.Select
   use Query.MutationSet
-  # use Query.Func
   use Query.Filter
   use Query.Block
   use Query.Directive

--- a/lib/dgraph_ex/query.ex
+++ b/lib/dgraph_ex/query.ex
@@ -98,7 +98,9 @@ defmodule DgraphEx.Query do
 
   defp render_assembled(assembled) do
     assembled
-    |> Enum.map(fn %{__struct__: module} = model -> module.render(model) end)
+    |> Enum.map(fn
+      %{__struct__: module} = model -> module.render(model)
+    end)
     |> Enum.join(" ")
   end
 
@@ -136,8 +138,11 @@ defmodule DgraphEx.Query do
   def assemble([Mutation, MutationSet, %Field{} = field | rest], %Mutation{} = mutation) do
     assemble([Mutation, MutationSet | rest], Mutation.put_set(mutation, field))
   end
+  def assemble([Mutation, %MutationSet{} = mset | rest ], %Mutation{} = mutation) do
+    assemble([Mutation | rest], Mutation.merge_set(mutation, mset))
+  end 
   # no more fields; done with MutationSet
-  def assemble([Mutation, MutationSet | rest], %Mutation{} = mutation) do
+  def assemble([Mutation, MutationSet | rest ], %Mutation{} = mutation) do
     assemble([Mutation | rest], mutation)
   end
   

--- a/lib/dgraph_ex/query/mutation.ex
+++ b/lib/dgraph_ex/query/mutation.ex
@@ -19,10 +19,22 @@ defmodule DgraphEx.Query.Mutation do
   defmacro __using__(_) do
     quote do
       alias DgraphEx.Query
-      def mutation(%Query{} = d) do
-        Query.put_sequence(d, Mutation)
+      alias DgraphEx.Query.Mutation
+      def mutation(%Query{} = q) do
+        Query.put_sequence(q, Mutation)
+      end
+      def mutation() do
+        mutation(%Query{})
       end
     end
+  end
+
+  def new() do
+    %Mutation{}
+  end
+
+  def merge_set(%Mutation{set: mset1} = mut, %MutationSet{} = mset2) do
+    %{ mut | set: %MutationSet{fields: mset2.fields ++ mset1.fields } }
   end
 
   def put_set(%Mutation{set: set} = m, %Field{} = f) do
@@ -47,8 +59,8 @@ defmodule DgraphEx.Query.Mutation do
         "" -> false
         item -> item
       end)
-      |> Enum.join("\n")
-    "mutation {\n" <> body <> "\n}"
+      |> Enum.join(" ")
+    "mutation { " <> body <> " }"
   end
 
 end

--- a/lib/dgraph_ex/query/mutation_set.ex
+++ b/lib/dgraph_ex/query/mutation_set.ex
@@ -8,10 +8,38 @@ defmodule DgraphEx.Query.MutationSet do
 
   defmacro __using__(_) do
     quote do
-      alias DgraphEx.Query
+      alias DgraphEx.{Query, Vertex}
+      alias Query.MutationSet
+
       def set(%Query{} = q) do
-        Query.put_sequence(q, Query.MutationSet)
+        Query.put_sequence(q, MutationSet)
       end
+
+      defp raise_vertex_only_error do
+        raise %ArgumentError{
+          message: "MutationSet.set structs must be Vertex models only"
+        }
+      end
+
+      def set(%Query{} = q, %{__struct__: module} = model) do
+        if DgraphEx.Util.has_function(module, :__vertex__, 1) do
+          subject = module.__vertex__(:default_label)
+          set(q, subject, model)
+        else
+          raise_vertex_only_error()
+        end
+      end
+
+      def set(%Query{} = q, subject, %{__struct__: module} = model) when is_atom(subject) do
+        if DgraphEx.Util.has_function(module, :__vertex__, 1) do
+          Query.put_sequence(q, %MutationSet{
+            fields: Vertex.populate_fields(subject, module, model)
+          })
+        else
+          raise_vertex_only_error()
+        end
+      end
+
     end
   end
 
@@ -23,6 +51,6 @@ defmodule DgraphEx.Query.MutationSet do
     ""
   end
   def render(%MutationSet{fields: fields}) when length(fields) > 0 do
-    " set { " <> (fields |> Enum.map(&Field.as_setter/1) |> Enum.join("\n")) <> " } "
+    "set { " <> (fields |> Enum.map(&Field.as_setter/1) |> Enum.join("\n")) <> " }"
   end
 end

--- a/lib/dgraph_ex/query/mutation_set.ex
+++ b/lib/dgraph_ex/query/mutation_set.ex
@@ -51,6 +51,13 @@ defmodule DgraphEx.Query.MutationSet do
     ""
   end
   def render(%MutationSet{fields: fields}) when length(fields) > 0 do
-    "set { " <> (fields |> Enum.map(&Field.as_setter/1) |> Enum.join("\n")) <> " }"
+    "set { " <> render_fields(fields) <> " }"
+  end
+
+  defp render_fields(fields) do
+    fields
+    |> Enum.map(&Field.as_setter/1)
+    |> List.flatten
+    |> Enum.join(" ")
   end
 end

--- a/lib/dgraph_ex/util.ex
+++ b/lib/dgraph_ex/util.ex
@@ -63,5 +63,8 @@ defmodule DgraphEx.Util do
   end
 
 
+  def has_function(module, func, arity) do
+    :erlang.function_exported(module, func, arity) 
+  end
 
 end

--- a/lib/dgraph_ex/vertex.ex
+++ b/lib/dgraph_ex/vertex.ex
@@ -80,8 +80,7 @@ defmodule DgraphEx.Vertex do
     populate_fields(subject, module, model)
   end
   def populate_fields(subject, module, model) do
-    :fields
-    |> module.__vertex__()
+    module.__vertex__(:fields)
     |> Enum.map(fn field ->
       object = Map.get(model, field.predicate, nil)
       if not is_nil(object) do

--- a/test/dgraph_ex_mutation_test.exs
+++ b/test/dgraph_ex_mutation_test.exs
@@ -3,15 +3,41 @@ defmodule DgraphEx.MutationTest do
   doctest DgraphEx.Query.Mutation
 
   import DgraphEx
+  import TestHelpers
+
+  alias DgraphEx.TestPerson, as: Person
+
+  test "render mutation set with a model" do
+    assert clean_format("""
+      mutation {
+        set {
+          _:person <name> \"Bleeeeeeeeeeeigh\"^^<xs:string> .
+          _:person <age> \"21\"^^<xs:int> .
+        }
+      }
+    """) ==
+      mutation()
+      |> set(%Person{
+        age: 21,
+        name: "Bleeeeeeeeeeeigh"
+      })
+      |> render
+
+
+  end
 
   test "render mutation set" do
-    result =
-      query()
-      |> mutation
-      |> set
-      |> field(:person, :name, "Jason", :string)
-      |> render
-    assert result == "mutation { set { _:person <name> \"Jason\"^^<xs:string> . } }"
+    assert clean_format("""
+      mutation {
+        set {
+          _:person <name> \"Jason\"^^<xs:string> .
+        }
+      }
+    """) ==
+    mutation()
+    |> set
+    |> field(:person, :name, "Jason", :string)
+    |> render
   end
 
 

--- a/test/dgraph_ex_mutation_test.exs
+++ b/test/dgraph_ex_mutation_test.exs
@@ -5,7 +5,8 @@ defmodule DgraphEx.MutationTest do
   import DgraphEx
   import TestHelpers
 
-  alias DgraphEx.TestPerson, as: Person
+  alias DgraphEx.ModelPerson, as: Person
+  alias DgraphEx.ModelCompany, as: Company
 
   test "render mutation set with a model" do
     assert clean_format("""
@@ -22,8 +23,6 @@ defmodule DgraphEx.MutationTest do
         name: "Bleeeeeeeeeeeigh"
       })
       |> render
-
-
   end
 
   test "render mutation set" do
@@ -40,6 +39,25 @@ defmodule DgraphEx.MutationTest do
     |> render
   end
 
+  test "render mutation set can handle a nested model" do
+    assert clean_format("""
+      mutation {
+        set {
+          _:company <name> "TurfBytes"^^<xs:string> .
+          _:company <owner> _:owner .
+          _:owner <name> "Jason"^^<xs:string> .
+        }
+      }
+    """) ==
+    mutation()
+    |> set(%Company{
+      name: "TurfBytes",
+      owner: %Person{
+        name: "Jason"
+      }
+    })
+    |> render
+  end
 
 
 end

--- a/test/model_company.exs
+++ b/test/model_company.exs
@@ -1,0 +1,9 @@
+defmodule DgraphEx.ModelCompany do
+  use DgraphEx.Vertex
+
+  vertex :company do
+    field :name, :string
+    field :owner, :uid, model: DgraphEx.ModelPerson, reverse: true
+  end
+
+end

--- a/test/model_person.exs
+++ b/test/model_person.exs
@@ -1,0 +1,10 @@
+defmodule DgraphEx.ModelPerson do
+  use DgraphEx.Vertex
+
+  vertex :person do
+    field :name,      :string
+    field :age,       :int
+    field :works_at,  :uid, model: DgraphEx.ModelCompany
+  end
+
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -10,12 +10,5 @@ defmodule TestHelpers do
 
 end
 
-defmodule DgraphEx.TestPerson do
-  use DgraphEx.Vertex
-
-  vertex :person do
-    field :name, :string
-    field :age,  :int
-  end
-
-end
+Code.load_file("./test/model_company.exs")
+Code.load_file("./test/model_person.exs")

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -9,3 +9,13 @@ defmodule TestHelpers do
   end
 
 end
+
+defmodule DgraphEx.TestPerson do
+  use DgraphEx.Vertex
+
+  vertex :person do
+    field :name, :string
+    field :age,  :int
+  end
+
+end


### PR DESCRIPTION
An example pull out of the tests:

```elixir
defmodule DgraphEx.ModelCompany do
  use DgraphEx.Vertex

  vertex :company do
    field :name, :string
    field :owner, :uid, model: DgraphEx.ModelPerson, reverse: true
  end

end
```

```elixir
defmodule DgraphEx.ModelPerson do
  use DgraphEx.Vertex

  vertex :person do
    field :name,      :string
    field :age,       :int
    field :works_at,  :uid, model: DgraphEx.ModelCompany
  end

end

```


```elixir
  test "render mutation set can handle a nested model" do
    assert clean_format("""
      mutation {
        set {
          _:company <name> "TurfBytes"^^<xs:string> .
          _:company <owner> _:owner .
          _:owner <name> "Jason"^^<xs:string> .
        }
      }
    """) ==
    mutation()
    |> set(%Company{
      name: "TurfBytes",
      owner: %Person{
        name: "Jason"
      }
    })
    |> render
  end
```